### PR TITLE
Save workspace vertex on import_obj for RE

### DIFF
--- a/src/index_runner/releng/import_obj.py
+++ b/src/index_runner/releng/import_obj.py
@@ -7,8 +7,8 @@ ws_object (unversioned)
     deleted
     _key: wsid/objid
 """
-import functools
 from src.index_runner.releng import genome
+from src.utils.run_func_once import run_once
 from src.utils.ws_utils import get_type_pieces
 from src.utils.re_client import save
 from src.utils.config import config
@@ -66,6 +66,7 @@ def import_object(obj_info):
 
 
 def _save_ws_object(key, wsid, objid):
+    """Runs at most every 300 seconds; otherwise a no-op."""
     print(f'Saving ws_object with key {key}')
     save('ws_object', [{
         '_key': key,
@@ -139,13 +140,13 @@ def _save_ws_contains_edge(obj_key, info_tup):
     to_id = 'ws_object/' + obj_key
     print(f'Saving ws_workspace_contains_obj edge from {from_id} to {to_id}')
     save('ws_workspace_contains_obj', {'_from': from_id, '_to': to_id})
-    _save_workspace(info_tup)
+    _save_workspace(info_tup[0])
 
 
-def _save_workspace(obj_info_tup):
+@run_once
+def _save_workspace(wsid):
     """Save the ws_workspace vertex given an object info tuple."""
     workspace_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
-    wsid = obj_info_tup[0]
     ws_info = workspace_client.admin_req('getWorkspaceInfo', {"id": wsid})
     # Workspace info tuple is as follows:
     #    0  1    2     3       4        5          6          7        8
@@ -204,7 +205,7 @@ def _save_inst_of_type_edge(obj_ver_key, info_tup):
     }])
 
 
-@functools.lru_cache(maxsize=128)
+@run_once
 def _save_type_vertex(obj_type):
     """Save associated vertices for an object type."""
     (type_module, type_name, type_ver) = get_type_pieces(obj_type)

--- a/src/index_runner/releng/import_obj.py
+++ b/src/index_runner/releng/import_obj.py
@@ -138,10 +138,32 @@ def _save_ws_contains_edge(obj_key, info_tup):
     from_id = 'ws_workspace/' + str(info_tup[6])
     to_id = 'ws_object/' + obj_key
     print(f'Saving ws_workspace_contains_obj edge from {from_id} to {to_id}')
-    save('ws_workspace_contains_obj', [{
-        '_from': from_id,
-        '_to': to_id
-    }])
+    save('ws_workspace_contains_obj', {'_from': from_id, '_to': to_id})
+    _save_workspace(info_tup)
+
+
+def _save_workspace(obj_info_tup):
+    """Save the ws_workspace vertex given an object info tuple."""
+    workspace_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
+    wsid = obj_info_tup[0]
+    print(f"OBJECT INFO! {wsid}   {obj_info_tup}")
+    print(f"GETTING WSINFO FOR {wsid}")
+    ws_info = workspace_client.admin_req('getWorkspaceInfo', {"id": wsid})
+    #  0  1    2     3       4        5          6          7        8
+    # [id,name,owner,moddate,maxobjid,user_perms,globalread,lockstat,metadata]
+    metadata = ws_info[-1]
+    print(f'Saving workspace vertex {wsid}')
+    save('ws_workspace', {
+        '_key': str(wsid),
+        'narr_name': metadata.get('narrative_nice_name', ''),
+        'owner': ws_info[2],
+        'max_obj_id': ws_info[4],
+        'lock_status': ws_info[7],
+        'name': ws_info[1],
+        'mod_epoch': ts_to_epoch(ws_info[3]),
+        'is_public': ws_info[6] == 'r',
+        'is_deleted': False
+    })
 
 
 def _save_created_with_method_edge(obj_ver_key, prov):

--- a/src/index_runner/releng/import_obj.py
+++ b/src/index_runner/releng/import_obj.py
@@ -146,11 +146,10 @@ def _save_workspace(obj_info_tup):
     """Save the ws_workspace vertex given an object info tuple."""
     workspace_client = WorkspaceClient(url=config()['kbase_endpoint'], token=config()['ws_token'])
     wsid = obj_info_tup[0]
-    print(f"OBJECT INFO! {wsid}   {obj_info_tup}")
-    print(f"GETTING WSINFO FOR {wsid}")
     ws_info = workspace_client.admin_req('getWorkspaceInfo', {"id": wsid})
-    #  0  1    2     3       4        5          6          7        8
-    # [id,name,owner,moddate,maxobjid,user_perms,globalread,lockstat,metadata]
+    # Workspace info tuple is as follows:
+    #    0  1    2     3       4        5          6          7        8
+    #   [id,name,owner,moddate,maxobjid,user_perms,globalread,lockstat,metadata]
     metadata = ws_info[-1]
     print(f'Saving workspace vertex {wsid}')
     save('ws_workspace', {

--- a/src/test/mock_kbase_services/workspace_get_workspace_info_5.json
+++ b/src/test/mock_kbase_services/workspace_get_workspace_info_5.json
@@ -1,0 +1,22 @@
+{
+  "methods": ["POST"],
+  "path": "/ws",
+  "headers": {"Authorization": "valid_admin_token"},
+  "body": {
+    "version": "1.1",
+    "method": "Workspace.administer",
+    "params": [{
+      "command": "getWorkspaceInfo",
+      "params": {"id": 5}
+    }]
+  },
+  "response": {
+    "status": "200",
+    "body": {
+      "version": "1.1",
+      "result": [
+        [5, "username:narrative_5", "username", "2019-04-05T22:17:00+0000", 12, "n", "r", "unlocked", {"searchtags": "narrative", "is_temporary": "false", "narrative": "1", "data_palette_id": "2", "cell_count": "1", "narrative_nice_name": "narr5"}]
+      ]
+    }
+  }
+}

--- a/src/test/mock_kbase_services/workspace_get_workspace_info_6.json
+++ b/src/test/mock_kbase_services/workspace_get_workspace_info_6.json
@@ -1,0 +1,23 @@
+{
+  "methods": ["POST"],
+  "path": "/ws",
+  "headers": {"Authorization": "valid_admin_token"},
+  "body": {
+    "version": "1.1",
+    "method": "Workspace.administer",
+    "params": [{
+      "command": "getWorkspaceInfo",
+      "params": {"id": 6}
+    }]
+  },
+  "response": {
+    "status": "200",
+    "body": {
+      "version": "1.1",
+      "result": [
+        [6, "username:narrative_6", "username", "2019-04-05T22:17:00+0000", 12, "n", "r", "unlocked", {"searchtags": "narrative", "is_temporary": "false", "narrative": "1", "data_palette_id": "2", "cell_count": "1", "narrative_nice_name": "narr6"}]
+      ]
+    }
+  }
+}
+

--- a/src/test/mock_kbase_services/workspace_get_workspace_info_7.json
+++ b/src/test/mock_kbase_services/workspace_get_workspace_info_7.json
@@ -1,0 +1,22 @@
+{
+  "methods": ["POST"],
+  "path": "/ws",
+  "headers": {"Authorization": "valid_admin_token"},
+  "body": {
+    "version": "1.1",
+    "method": "Workspace.administer",
+    "params": [{
+      "command": "getWorkspaceInfo",
+      "params": {"id": 7}
+    }]
+  },
+  "response": {
+    "status": "200",
+    "body": {
+      "version": "1.1",
+      "result": [
+        [7, "username:narrative_7", "username", "2019-04-05T22:17:00+0000", 12, "n", "r", "unlocked", {"searchtags": "narrative", "is_temporary": "false", "narrative": "1", "data_palette_id": "2", "cell_count": "1", "narrative_nice_name": "narr7"}]
+      ]
+    }
+  }
+}

--- a/src/test/mock_kbase_services/workspace_get_workspace_info_8.json
+++ b/src/test/mock_kbase_services/workspace_get_workspace_info_8.json
@@ -1,0 +1,22 @@
+{
+  "methods": ["POST"],
+  "path": "/ws",
+  "headers": {"Authorization": "valid_admin_token"},
+  "body": {
+    "version": "1.1",
+    "method": "Workspace.administer",
+    "params": [{
+      "command": "getWorkspaceInfo",
+      "params": {"id": 8}
+    }]
+  },
+  "response": {
+    "status": "200",
+    "body": {
+      "version": "1.1",
+      "result": [
+        [8, "username:narrative_8", "username", "2019-04-05T22:17:00+0000", 12, "n", "r", "unlocked", {"searchtags": "narrative", "is_temporary": "false", "narrative": "1", "data_palette_id": "2", "cell_count": "1", "narrative_nice_name": "narr8"}]
+      ]
+    }
+  }
+}

--- a/src/test/mock_kbase_services/workspace_get_workspace_info_9.json
+++ b/src/test/mock_kbase_services/workspace_get_workspace_info_9.json
@@ -1,0 +1,23 @@
+{
+  "methods": ["POST"],
+  "path": "/ws",
+  "headers": {"Authorization": "valid_admin_token"},
+  "body": {
+    "version": "1.1",
+    "method": "Workspace.administer",
+    "params": [{
+      "command": "getWorkspaceInfo",
+      "params": {"id": 9}
+    }]
+  },
+  "response": {
+    "status": "200",
+    "body": {
+      "version": "1.1",
+      "result": [
+        [5, "username:narrative_9", "username", "2019-04-05T22:17:00+0000", 12, "n", "r", "unlocked", {"searchtags": "narrative", "is_temporary": "false", "narrative": "1", "data_palette_id": "2", "cell_count": "1", "narrative_nice_name": "narr9"}]
+      ]
+    }
+  }
+}
+

--- a/src/test/test_releng_import_object.py
+++ b/src/test/test_releng_import_object.py
@@ -143,9 +143,10 @@ class TestRelEngImportObject(unittest.TestCase):
         (type_module, type_name, maj_ver, min_ver) = ("KBaseGenomes", "Genome", 15, 1)
         obj_type = f"{type_module}.{type_name}-{maj_ver}.{min_ver}"
         # trigger the import
+        wsid = 7
         import_object({
             "info": [
-                7,
+                wsid,
                 "my_genome",
                 obj_type,
                 "2016-10-05T17:11:32+0000",
@@ -157,7 +158,7 @@ class TestRelEngImportObject(unittest.TestCase):
                 351,
                 {}
             ]
-            })
+        })
         # check results
         obj_doc = get_re_doc('ws_object', '6:7')
         self.assertEqual(obj_doc['workspace_id'], 6)
@@ -218,6 +219,16 @@ class TestRelEngImportObject(unittest.TestCase):
             'ws_object_version/6:7:8',  # from
             'ws_type_version/KBaseGenomes.Genome-15.1'  # to
         )
+        # Check for the workspace vertex
+        self.assertDictContainsSubset({
+            '_key': str(wsid),
+            'narr_name': 'narr7',
+            'owner': 'username',
+            'lock_status': 'unlocked',
+            'name': 'username:narrative_7',
+            'is_public': True,
+            'is_deleted': False
+        }, get_re_doc('ws_workspace', str(wsid)))
         # Check for type vertices
         self.assertDictContainsSubset({
             '_key': 'KBaseGenomes.Genome-15.1',

--- a/src/test/test_run_func_once.py
+++ b/src/test/test_run_func_once.py
@@ -1,0 +1,33 @@
+import unittest
+
+from src.utils.run_func_once import run_once
+
+
+class TestRunFuncOnce(unittest.TestCase):
+
+    def test_run_once(self):
+        """Test with an argument."""
+        count = 0
+
+        @run_once
+        def add(n):
+            nonlocal count
+            count += n
+        add(1)
+        add(1)
+        add(2)
+        add(2)
+        self.assertEqual(count, 3)
+
+    def test_run_once_no_args(self):
+        """Test with no args."""
+        count = 0
+
+        @run_once
+        def incr():
+            nonlocal count
+            count += 1
+        incr()
+        incr()
+        incr()
+        self.assertEqual(count, 1)

--- a/src/utils/run_func_once.py
+++ b/src/utils/run_func_once.py
@@ -1,0 +1,19 @@
+"""
+Utilities for running functions a limited amount of times.
+"""
+
+
+def run_once(fn):
+    """
+    Decorator that runs the function only once for a set of args. No-op on subsequent calls.
+    Does not work with keyword args for now.
+    """
+    # Args we have already seen
+    seen = set()  # type: set
+
+    def _wrapper(*args):
+        arg_str = str(args)
+        if arg_str not in seen:
+            seen.add(arg_str)
+            fn(*args)
+    return _wrapper


### PR DESCRIPTION
This will create or update the workspace vertex on every object import into RE. I figure it's a small network request, plus some of the workspace data is mutable, so it's worth running on every event rather than caching