### PR TITLE
Sanitize arango keys for features

### DIFF
--- a/src/index_runner/releng/genome.py
+++ b/src/index_runner/releng/genome.py
@@ -11,6 +11,8 @@ import itertools as _itertools
 
 from src.utils.re_client import stored_query as _stored_query
 from src.utils.re_client import save as _save
+# may want to html encode vs replace with _ to avoid collisions? Seems really improbable
+from src.utils.re_client import clean_key as _clean_key
 from src.utils.re_client import MAX_ADB_INTEGER as _MAX_ADB_INTEGER
 
 _OBJ_VER_COLL = "ws_object_version"
@@ -85,7 +87,7 @@ def _generate_features(obj_ver_key, obj_data):
     ver = obj_data['info'][4]
     # might want to do this in smaller batches if memory pressure is an issue
     for f in d['features']:
-        feature_key = f'{obj_ver_key}_{f["id"]}'  # check f['id'] for weird chars?
+        feature_key = _clean_key(f'{obj_ver_key}_{f["id"]}')
         verts.append({
             '_key': feature_key,
             'workspace_id': wsid,
@@ -131,9 +133,10 @@ def _generate_GO_links(obj_ver_key, obj_data):
             if g not in resolved_terms:
                 print(f"Couldn't resolve GO term {g} in Genome {obj_ver_key} feature {f}")
             else:
+                featurekey = _clean_key(f'{obj_ver_key}_{f}')
                 edges.append({
-                    '_key': f'{obj_ver_key}_{f}::{resolved_terms[g]}::kbase_RE_indexer',
-                    '_from': f'{_WS_FEAT_COLL}/{obj_ver_key}_{f}',
+                    '_key': f'{featurekey}::{resolved_terms[g]}::kbase_RE_indexer',
+                    '_from': f'{_WS_FEAT_COLL}/{featurekey}',
                     '_to': f'{_GO_TERM_COLL}/{resolved_terms[g]}',
                     'source': 'kbase_RE_indexer',
                     'expired': _MAX_ADB_INTEGER

--- a/src/test/mock_kbase_services/workspace_get_objects_6_7_8_genome.json
+++ b/src/test/mock_kbase_services/workspace_get_objects_6_7_8_genome.json
@@ -21,7 +21,7 @@
                           "data": {
                               "taxonomy": "Bacteria;Firmicutes;Bacilli;Bacillales;Bacillaceae;Bacillus;Bacillus subtilis",
                               "features": [
-                                  {"id": "id1",
+                                  {"id": "id1-|o",
                                    "ontology_terms": {
                                         "ignore": {"t1": [5, 7, 8]},
                                         "GO": {

--- a/src/test/test_releng_import_object.py
+++ b/src/test/test_releng_import_object.py
@@ -132,8 +132,8 @@ class TestRelEngImportObject(unittest.TestCase):
 
         # add an edge that already exists and so should not be overwritten
         save('ws_feature_has_GO_annotation', [
-            {'_key': '6:7:8_id1::GO:2_v1::kbase_RE_indexer',
-             '_from': 'ws_genome_features/6:7:8_id1',
+            {'_key': '6:7:8_id1-_o::GO:2_v1::kbase_RE_indexer',
+             '_from': 'ws_genome_features/6:7:8_id1-_o',
              '_to': 'GO_terms/GO:2_v1',
              'source': 'kbase_RE_indexer',
              'expired': re_client.MAX_ADB_INTEGER,
@@ -265,15 +265,15 @@ class TestRelEngImportObject(unittest.TestCase):
             'assigned_by': '_system'
         })
 
-        f1 = get_re_doc('ws_genome_features', '6:7:8_id1')
+        f1 = get_re_doc('ws_genome_features', '6:7:8_id1-_o')
         del f1['updated_at']
         self.assertEqual(f1, {
-            '_key': '6:7:8_id1',
-            '_id': 'ws_genome_features/6:7:8_id1',
+            '_key': '6:7:8_id1-_o',
+            '_id': 'ws_genome_features/6:7:8_id1-_o',
             'workspace_id': 6,
             'object_id': 7,
             'version': 8,
-            'feature_id': 'id1'})
+            'feature_id': 'id1-|o'})
 
         f2 = get_re_doc('ws_genome_features', '6:7:8_id2')
         del f2['updated_at']
@@ -288,14 +288,14 @@ class TestRelEngImportObject(unittest.TestCase):
         e1 = get_re_edge(
             'ws_genome_has_feature',
             'ws_object_version/6:7:8',
-            'ws_genome_features/6:7:8_id1',
+            'ws_genome_features/6:7:8_id1-_o',
             False)
         del e1['updated_at']
         self.assertEqual(e1, {
-            '_key': '6:7:8_id1',
-            '_id': 'ws_genome_has_feature/6:7:8_id1',
+            '_key': '6:7:8_id1-_o',
+            '_id': 'ws_genome_has_feature/6:7:8_id1-_o',
             '_from': 'ws_object_version/6:7:8',
-            '_to': 'ws_genome_features/6:7:8_id1',
+            '_to': 'ws_genome_features/6:7:8_id1-_o',
         })
         e2 = get_re_edge(
             'ws_genome_has_feature',
@@ -326,23 +326,23 @@ class TestRelEngImportObject(unittest.TestCase):
                 self.assertEqual(created, 678)
 
         expected = [
-            {'_key': '6:7:8_id1::GO:1_v2::kbase_RE_indexer',
-             '_id': 'ws_feature_has_GO_annotation/6:7:8_id1::GO:1_v2::kbase_RE_indexer',
-             '_from': 'ws_genome_features/6:7:8_id1',
+            {'_key': '6:7:8_id1-_o::GO:1_v2::kbase_RE_indexer',
+             '_id': 'ws_feature_has_GO_annotation/6:7:8_id1-_o::GO:1_v2::kbase_RE_indexer',
+             '_from': 'ws_genome_features/6:7:8_id1-_o',
              '_to': 'GO_terms/GO:1_v2',
              'source': 'kbase_RE_indexer',
              'expired': 9007199254740991,
              },
-            {'_key': '6:7:8_id1::GO:2_v1::kbase_RE_indexer',
-             '_id': 'ws_feature_has_GO_annotation/6:7:8_id1::GO:2_v1::kbase_RE_indexer',
-             '_from': 'ws_genome_features/6:7:8_id1',
+            {'_key': '6:7:8_id1-_o::GO:2_v1::kbase_RE_indexer',
+             '_id': 'ws_feature_has_GO_annotation/6:7:8_id1-_o::GO:2_v1::kbase_RE_indexer',
+             '_from': 'ws_genome_features/6:7:8_id1-_o',
              '_to': 'GO_terms/GO:2_v1',
              'source': 'kbase_RE_indexer',
              'expired': 9007199254740991,
              },
-            {'_key': '6:7:8_id1::GO:5_v1::kbase_RE_indexer',
-             '_id': 'ws_feature_has_GO_annotation/6:7:8_id1::GO:5_v1::kbase_RE_indexer',
-             '_from': 'ws_genome_features/6:7:8_id1',
+            {'_key': '6:7:8_id1-_o::GO:5_v1::kbase_RE_indexer',
+             '_id': 'ws_feature_has_GO_annotation/6:7:8_id1-_o::GO:5_v1::kbase_RE_indexer',
+             '_from': 'ws_genome_features/6:7:8_id1-_o',
              '_to': 'GO_terms/GO:5_v1',
              'source': 'kbase_RE_indexer',
              'expired': 9007199254740991,


### PR DESCRIPTION
Features can have all kinds of characters in them - swap them
for underscore.

It's possible, although extremely improbable, that keys could be identical other
than disallowed characters in the same spot, in which case this could cause
key collisions. YAGNI for now due to improbability.