### PR TITLE
Fix tests

### DIFF
--- a/src/test/test_integration.py
+++ b/src/test/test_integration.py
@@ -6,6 +6,7 @@ from confluent_kafka import Producer
 
 from src.utils.config import config
 from src.utils.re_client import get_doc
+from src.utils.service_utils import wait_for_dependencies
 
 _TEST_EVENT = {
    "wsid": 33192,
@@ -29,6 +30,10 @@ class TestIntegration(unittest.TestCase):
     unit tests. Including them here will be too slow.
     """
     maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        wait_for_dependencies()
 
     def test_integration(self):
         # Produce an event on Kafka

--- a/src/utils/service_utils.py
+++ b/src/utils/service_utils.py
@@ -31,6 +31,7 @@ def _wait_for_service(url, name, start_time, timeout, params=None):
         try:
             logger.info(f'Waiting for {name} service...')
             requests.get(url, params=params).raise_for_status()
+            logger.info(f'{name} is up!')
             break
         except Exception:
             time.sleep(5)


### PR DESCRIPTION
Tests need to block on elasticsearch and RE API going live. At some point we lost this. My fault I'm sure.