### PR TITLE
Log all messages

### DIFF
--- a/src/test/test_integration.py
+++ b/src/test/test_integration.py
@@ -47,6 +47,8 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(es_doc['_id'], es_id)
         self.assertEqual(re_doc['workspace_id'], wsid)
         self.assertEqual(re_doc['object_id'], objid)
+        log_doc = _get_es_doc_blocking(_TEST_EVENT['time'])
+        self.assertEqual(log_doc['_source'], _TEST_EVENT)
 
 
 # -- Test utils

--- a/src/test/test_integration.py
+++ b/src/test/test_integration.py
@@ -6,6 +6,7 @@ from confluent_kafka import Producer
 
 from src.utils.config import config
 from src.utils.re_client import get_doc
+from src.utils.service_utils import wait_for_dependencies
 
 _TEST_EVENT = {
    "wsid": 33192,
@@ -29,6 +30,10 @@ class TestIntegration(unittest.TestCase):
     unit tests. Including them here will be too slow.
     """
     maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        wait_for_dependencies()
 
     def test_integration(self):
         # Produce an event on Kafka

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -68,6 +68,7 @@ def get_config():
         'kafka_server': os.environ.get('KAFKA_SERVER', 'kafka'),
         'kafka_clientgroup': os.environ.get('KAFKA_CLIENTGROUP', 'search_indexer'),
         'error_index_name': os.environ.get('ERROR_INDEX_NAME', 'indexing_errors'),
+        'msg_log_index_name': os.environ.get('MSG_LOG_INDEX_NAME', 'indexer_messages'),
         'elasticsearch_index_prefix': os.environ.get('ELASTICSEARCH_INDEX_PREFIX', 'search2'),
         'topics': {
             'workspace_events': os.environ.get('KAFKA_WORKSPACE_TOPIC', 'workspaceevents'),

--- a/src/utils/service_utils.py
+++ b/src/utils/service_utils.py
@@ -31,6 +31,7 @@ def _wait_for_service(url, name, start_time, timeout, params=None):
         try:
             logger.info(f'Waiting for {name} service...')
             requests.get(url, params=params).raise_for_status()
+            logger.info(f'{name} is up!')
             break
         except Exception:
             time.sleep(5)


### PR DESCRIPTION
Log all messages received by the kafka consumer to an elasticsearch index.

Also see https://github.com/kbase/index_runner_spec/pull/13