### PR TITLE
A couple minor cleanups and one more important fix

### DIFF
--- a/src/index_runner/es_indexer.py
+++ b/src/index_runner/es_indexer.py
@@ -171,7 +171,8 @@ def _init_generic_index(msg):
     """
     (_, type_name, type_ver) = get_type_pieces(msg['full_type_name'])
     index_name = type_name.lower()
-    _init_index(index_name + '_0', _GLOBAL_MAPPINGS['ws_object'])
+    mappings = {**_GLOBAL_MAPPINGS['ws_auth'], **_GLOBAL_MAPPINGS['ws_object']}
+    _init_index(index_name + '_0', mappings)
 
 
 def _write_to_elastic(data):
@@ -200,7 +201,7 @@ def _write_to_elastic(data):
     # Save the documents using the elasticsearch http api
     resp = requests.post(f"{_ES_URL}/_bulk", data=json_body, headers={"Content-Type": "application/json"})
     if not resp.ok:
-        # Unsuccesful save to elasticsearch.
+        # Unsuccessful save to elasticsearch.
         raise RuntimeError(f"Error saving to elasticsearch:\n{resp.text}")
 
 

--- a/src/index_runner/es_indexers/main.py
+++ b/src/index_runner/es_indexers/main.py
@@ -60,17 +60,17 @@ def index_obj(obj_data, ws_info, msg_data):
     defaults = indexer_utils.default_fields(obj_data, ws_info, obj_data_v1)
     for indexer_ret in indexer(obj_data, ws_info, obj_data_v1):
         if indexer_ret['_action'] == 'index':
+            if config()['allow_indices'] and indexer_ret.get('index') not in config()['allow_indices']:
+                # This index name is not in the indexing whitelist from the config, so we skip
+                logger.debug(f"Index '{indexer_ret['index']}' is not in ALLOW_INDICES, skipping")
+                continue
+            if indexer_ret.get('index') in config()['skip_indices']:
+                # This index name is in the indexing blacklist in the config, so we skip
+                logger.debug(f"Index '{indexer_ret['index']}' is in SKIP_INDICES, skipping")
+                continue
             if '_no_defaults' not in indexer_ret:
                 # Inject all default fields into the index document.
                 indexer_ret['doc'].update(defaults)
-            # if not indexer_ret.get('namespace'):
-            #     indexer_ret['namespace'] = "WS"
-        if config()['allow_indices'] and indexer_ret.get('index') not in config()['allow_indices']:
-            logger.debug(f"Index '{indexer_ret['index']}' is not in ALLOW_INDICES, skipping")
-            continue
-        if indexer_ret.get('index') in config()['skip_indices']:
-            logger.debug(f"Index '{indexer_ret['index']}' is in SKIP_INDICES, skipping")
-            continue
         yield indexer_ret
 
 


### PR DESCRIPTION
Minor tweaks:
* Clean up conditionals in top-level event handler to prevent downloading a WS object in certain rare cases
* Clean up the conditonal in the top level es_indexers iterator slightly

Fairly important fix:
* Generic index type mappings (indexes that are not handled by an sdk app or module) need to include the 'ws_auth' global type mapping. This was working okay before because ES will initialize some default types for us. But we do want to make sure to use our explicit types.