### PR TITLE
Fix typo in replica count config

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -81,7 +81,7 @@ def get_config():
         'last_config_reload': time.time(),
         'proc_ready_path': proc_ready_path,  # File indicating the daemon is booted and ready
         'generic_shard_count': os.environ.get('GENERIC_SHARD_COUNT', 2),
-        'generic_replica_count': os.environ.get('GENERIC_SHARD_COUNT', 1),
+        'generic_replica_count': os.environ.get('GENERIC_REPLICA_COUNT', 1),
     }
 
 


### PR DESCRIPTION
Addresses part of #123 

Typo in some quick PR configuring default replica count for new indexes.